### PR TITLE
Implement bulk film activity retrieval

### DIFF
--- a/frontend/src/components/home/LatestPosters.jsx
+++ b/frontend/src/components/home/LatestPosters.jsx
@@ -1,11 +1,13 @@
 import PropTypes from "prop-types";
-import { memo, useCallback } from "react";
+import { memo, useCallback, useMemo } from "react";
 import HorizontalGrid from "../ui/HorizontalGrid";
 import FilmCard from "../../features/films/FilmCard";
 import useUserStore from "../../store/user/userStore";
+import useBulkFilmActivities from "@/hooks/useBulkFilmActivities";
 
 function LatestPosters({ films = [], isFriendsActivity = false }) {
   const { user } = useUserStore();
+  useBulkFilmActivities(useMemo(() => films.map((f) => f.id), [films]));
 
   const renderItem = useCallback(
     (film) => (

--- a/frontend/src/features/films/FilmGrid.jsx
+++ b/frontend/src/features/films/FilmGrid.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import FilmCard from "./FilmCard";
 import { getFilmsByPerson } from "../../services/films/persons";
 import { fetchFilteredFilms } from "../../services/films/films";
+import useBulkFilmActivities from "@/hooks/useBulkFilmActivities";
 import { Button } from "@/components/ui/Button";
 import FilterSortBar from "./grid_adds/FilterSortBar";
 import DropdownSelector from "./grid_adds/DropdownSelector";
@@ -52,6 +53,8 @@ export default function FilmGrid({
   const [loading, setLoading] = useState(true);
 
   const pageSize = useMemo(() => pageSizes[cardSize], [cardSize]);
+
+  useBulkFilmActivities(useMemo(() => films.map((f) => f.id), [films]));
 
   useEffect(() => {
     if (!searchParams.get("sort") && defaultSort) {

--- a/frontend/src/hooks/useBulkFilmActivities.js
+++ b/frontend/src/hooks/useBulkFilmActivities.js
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+import useUserStore from "@/store/user/userStore";
+import useFilmActivityStore from "@/store/film/useFilmActivityStore";
+import { getUserFilmActivities } from "@/services/users/users";
+
+export default function useBulkFilmActivities(filmIds = []) {
+  const { user } = useUserStore();
+  const setActivities = useFilmActivityStore((state) => state.setActivities);
+
+  useEffect(() => {
+    if (!user || !Array.isArray(filmIds) || filmIds.length === 0) return;
+
+    const controller = new AbortController();
+    getUserFilmActivities(filmIds, controller.signal)
+      .then((data) => {
+        if (data) setActivities(data);
+      })
+      .catch((err) => {
+        console.error("Failed to load film activities", err);
+      });
+
+    return () => controller.abort();
+  }, [user, filmIds, setActivities]);
+}

--- a/frontend/src/hooks/useFilmUserActivity.js
+++ b/frontend/src/hooks/useFilmUserActivity.js
@@ -16,6 +16,7 @@ export default function useFilmUserActivity(filmId) {
   const watched = useFilmActivityStore((state) => state.activityByFilmId[filmId]?.watched ?? false);
   const rating = useFilmActivityStore((state) => state.activityByFilmId[filmId]?.rating ?? 0);
   const watchlisted = useFilmActivityStore((state) => state.activityByFilmId[filmId]?.watchlisted ?? false);
+  const hasActivity = useFilmActivityStore((state) => state.activityByFilmId[filmId] !== undefined);
   const setActivity = useFilmActivityStore((state) => state.setActivity);
 
   const [loading, setLoading] = useState(false);
@@ -45,8 +46,9 @@ export default function useFilmUserActivity(filmId) {
   }, [filmId, user, setActivity]);
 
   useEffect(() => {
+    if (!user || !filmId || hasActivity) return;
     fetchActivity();
-  }, [fetchActivity]);
+  }, [fetchActivity, user, filmId, hasActivity]);
 
   const updateField = useCallback(
     (field, value) => {

--- a/frontend/src/services/users/users.js
+++ b/frontend/src/services/users/users.js
@@ -54,3 +54,7 @@ export const deleteWatchlistEntry = async (filmId, signal = null) => {
     throw err;
   }
 };
+
+export const getUserFilmActivities = (filmIds = [], signal = null) => {
+  return postData(`/users/film-activities/`, { film_ids: filmIds }, { signal });
+};

--- a/frontend/src/store/film/useFilmActivityStore.js
+++ b/frontend/src/store/film/useFilmActivityStore.js
@@ -19,6 +19,23 @@ const useFilmActivityStore = create((set, get) => ({
       },
     })),
 
+  setActivities: (activities) =>
+    set((state) => {
+      const updated = { ...state.activityByFilmId };
+      Object.entries(activities || {}).forEach(([id, data]) => {
+        updated[id] = {
+          ...(state.activityByFilmId[id] || {
+            liked: false,
+            watched: false,
+            rating: 0,
+            watchlisted: false,
+          }),
+          ...data,
+        };
+      });
+      return { activityByFilmId: updated };
+    }),
+
   getActivity: (filmId) =>
     get().activityByFilmId[filmId] || {
       liked: false,

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path, include
 from .views.auth_view import LoginView, RegisterView, CurrentUserView
-from .views.film_and_user_views import FilmUserActivityViewSet
+from .views.film_and_user_views import FilmUserActivityViewSet, FilmActivitiesView
 from .views.friends_lists_views import FriendsListsView
 from .views.popular_lists_views import PopularListsView
 from .views.watchlist_views import ToggleWatchlistEntryView
@@ -11,12 +11,14 @@ film_user_activity = FilmUserActivityViewSet.as_view({
     "post": "create",
     "delete": "destroy",
 })
+film_activities = FilmActivitiesView.as_view({"post": "list"})
 urlpatterns = [
     path('login/', LoginView.as_view(), name='login'),
     path('register/', RegisterView.as_view(), name='register'),
     path('me/', CurrentUserView.as_view(), name='me'),
     path("film-activity/<int:film_id>/", film_user_activity, name="film-user-activity"),
     path("film-activity/<int:film_id>/watchlist/", ToggleWatchlistEntryView.as_view(), name="toggle-watchlist"),
+    path("film-activities/", film_activities, name="film-activities"),
 
     path('lists/', include([
     path('popular/', PopularListsView.as_view(), name='popular-lists'),


### PR DESCRIPTION
## Summary
- support retrieving many film activity entries in one request
- handle bulk film activity results in store
- use the bulk activity API from FilmGrid and LatestPosters
- avoid refetching activity data when already stored

## Testing
- `npm run lint` *(fails: '@eslint/js' missing and other lint errors)*
- `python manage.py test` *(fails: SyntaxError in settings.py)*

------
https://chatgpt.com/codex/tasks/task_e_6844b238df80832db3655a2dcf966bab