### PR TITLE
Handle abort signal in film activity hook

### DIFF
--- a/frontend/src/hooks/useFilmUserActivity.js
+++ b/frontend/src/hooks/useFilmUserActivity.js
@@ -21,14 +21,14 @@ export default function useFilmUserActivity(filmId) {
   const [loading, setLoading] = useState(false);
   const [togglingWatchlist, setTogglingWatchlist] = useState(false);
 
-  const fetchActivity = useCallback(() => {
+  const fetchActivity = useCallback((signal = null) => {
     if (!user || !filmId) return;
 
     setLoading(true);
 
     Promise.all([
-      getUserFilmActivity(filmId),
-      getWatchlistStatus(filmId),
+      getUserFilmActivity(filmId, signal),
+      getWatchlistStatus(filmId, signal),
     ])
       .then(([activityData, watchlistData]) => {
         setActivity(filmId, {
@@ -45,7 +45,9 @@ export default function useFilmUserActivity(filmId) {
   }, [filmId, user, setActivity]);
 
   useEffect(() => {
-    fetchActivity();
+    const controller = new AbortController();
+    fetchActivity(controller.signal);
+    return () => controller.abort();
   }, [fetchActivity]);
 
   const updateField = useCallback(


### PR DESCRIPTION
## Summary
- pass signal to `getUserFilmActivity` and `getWatchlistStatus`
- abort requests in `useFilmUserActivity`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js', then shows 15 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6844b23b09d8832d9822bfec43ef24b3