### PR TITLE
Persist film activity in localStorage

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,10 +1,12 @@
 import { useEffect } from "react";
 import useUserStore from "./store/user/userStore";
+import useFilmActivityStore from "./store/film/useFilmActivityStore";
 import AppRoutes from "./routes";
 
 export default function App() {
   useEffect(() => {
     useUserStore.getState().loadUserFromStorage();
+    useFilmActivityStore.getState().loadActivityFromStorage();
   }, []);
 
   return <AppRoutes />;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -5,9 +5,11 @@ import App from "./App.jsx";
 import "./index.css";
 
 import useUserStore from "./store/user/userStore";
+import useFilmActivityStore from "./store/film/useFilmActivityStore";
 
 // --- Load user on refresh --- //
 useUserStore.getState().loadUserFromStorage();
+useFilmActivityStore.getState().loadActivityFromStorage();
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>

--- a/frontend/src/store/film/useFilmActivityStore.js
+++ b/frontend/src/store/film/useFilmActivityStore.js
@@ -1,23 +1,27 @@
 import { create } from "zustand";
 
+const STORAGE_KEY = "filmActivity";
+
 const useFilmActivityStore = create((set, get) => ({
   activityByFilmId: {},
 
   setActivity: (filmId, updates) =>
-    set((state) => ({
-      activityByFilmId: {
+    set((state) => {
+      const activityByFilmId = {
         ...state.activityByFilmId,
         [filmId]: {
           ...(state.activityByFilmId[filmId] || {
             liked: false,
             watched: false,
             rating: 0,
-            watchlisted: false, 
+            watchlisted: false,
           }),
           ...updates,
         },
-      },
-    })),
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(activityByFilmId));
+      return { activityByFilmId };
+    }),
 
   getActivity: (filmId) =>
     get().activityByFilmId[filmId] || {
@@ -26,6 +30,13 @@ const useFilmActivityStore = create((set, get) => ({
       rating: 0,
       watchlisted: false,
     },
+
+  loadActivityFromStorage: () => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      set({ activityByFilmId: JSON.parse(stored) });
+    }
+  },
 }));
 
 


### PR DESCRIPTION
## Summary
- persist film activity to `localStorage`
- reload film activity state at app startup

## Testing
- `npm run lint` *(fails: `'user' is assigned a value but never used` etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6844b23cd72c832d9bde95ca5fd220f8