### PR TITLE
Add AbortController to PersonStats

### DIFF
--- a/frontend/src/features/films/persons/PersonStats.jsx
+++ b/frontend/src/features/films/persons/PersonStats.jsx
@@ -6,10 +6,14 @@ export default function PersonStats({ personId, totalFilms }) {
   const [seenCount, setSeenCount] = useState(0);
 
   useEffect(() => {
+    const controller = new AbortController();
+
     axios
-      .get(`/users/me/stats/person/${personId}/`)
+      .get(`/users/me/stats/person/${personId}/`, { signal: controller.signal })
       .then((res) => setSeenCount(res.data.seen))
       .catch(() => {});
+
+    return () => controller.abort();
   }, [personId]);
 
   const percent = totalFilms > 0 ? Math.round((seenCount / totalFilms) * 100) : 0;


### PR DESCRIPTION
## Summary
- manage in-flight requests in `PersonStats` with AbortController

## Testing
- `npm run lint` *(fails: cannot find @eslint/js and lints fail)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6844b25f8590832db22c6128f88f4352