### PR TITLE
Lazy load LogModal component

### DIFF
--- a/frontend/src/components/ui/icons/PencilIcon.jsx
+++ b/frontend/src/components/ui/icons/PencilIcon.jsx
@@ -1,8 +1,8 @@
-import { useState } from "react";
+import { useState, lazy, Suspense } from "react";
 import { PencilLine } from "lucide-react";
 import PropTypes from "prop-types";
 import clsx from "clsx";
-import LogModal from "@/features/reviews/LogModal";
+const LogModal = lazy(() => import("@/features/reviews/LogModal"));
 
 // Función local para evitar imports fantasmas
 const getSizedPosterUrl = (url, size = "md") => {
@@ -61,20 +61,22 @@ export default function PencilIcon({
       />
 
       {film && (
-        <LogModal
-          isOpen={showModal}
-          onClose={() => setShowModal(false)}
-          film={{
-            id: film.id,
-            title: film.title,
-            year: film.year,
-            posterUrl: getSizedPosterUrl(film.posterUrl, "md"),
-          }}
-          onSave={(data) => {
-            console.log("📝 Saved from PencilIcon", data);
-            setShowModal(false);
-          }}
-        />
+        <Suspense fallback={<div className="text-gray-400 p-4">Loading...</div>}>
+          <LogModal
+            isOpen={showModal}
+            onClose={() => setShowModal(false)}
+            film={{
+              id: film.id,
+              title: film.title,
+              year: film.year,
+              posterUrl: getSizedPosterUrl(film.posterUrl, "md"),
+            }}
+            onSave={(data) => {
+              console.log("📝 Saved from PencilIcon", data);
+              setShowModal(false);
+            }}
+          />
+        </Suspense>
       )}
     </>
   );

--- a/frontend/src/features/films/FilmUserActions.jsx
+++ b/frontend/src/features/films/FilmUserActions.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, lazy, Suspense } from "react";
 import useUserStore from "@/store/user/userStore";
 import useFilmUserActivity from "@/hooks/useFilmUserActivity";
 import EyeIcon from "@/components/ui/icons/EyeIcon";
@@ -8,7 +8,7 @@ import PencilIcon from "@/components/ui/icons/PencilIcon";
 import ListIcon from "@/components/ui/icons/ListIcon";
 import StarRating from "@/components/ui/StarRating";
 import { Button } from "@/components/ui/Button";
-import LogModal from "@/features/reviews/LogModal";
+const LogModal = lazy(() => import("@/features/reviews/LogModal"));
 
 export default function FilmUserActions({ filmId, onTriggerLogin, filmData }) {
   const { user } = useUserStore();
@@ -92,15 +92,17 @@ export default function FilmUserActions({ filmId, onTriggerLogin, filmData }) {
       </div>
 
       {/* Modal de log */}
-      <LogModal
-        isOpen={showModal}
-        onClose={() => setShowModal(false)}
-        film={filmData}
-        onSave={() => {
-          refetch();
-          setShowModal(false);
-        }}
-      />
+      <Suspense fallback={<div className="text-gray-400 p-4">Loading...</div>}>
+        <LogModal
+          isOpen={showModal}
+          onClose={() => setShowModal(false)}
+          film={filmData}
+          onSave={() => {
+            refetch();
+            setShowModal(false);
+          }}
+        />
+      </Suspense>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- lazy load `LogModal` in `PencilIcon` and `FilmUserActions`
- suspend `LogModal` rendering with a fallback loader

## Testing
- `npm test` *(fails: Missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6844b2611930832d95a5cde909ea6831