### PR TITLE
Optimize film header and grid pagination

### DIFF
--- a/frontend/src/features/films/FilmGrid.jsx
+++ b/frontend/src/features/films/FilmGrid.jsx
@@ -141,6 +141,22 @@ export default function FilmGrid({
       )
     : [];
 
+  const paginationPages = useMemo(() => {
+    return Array.from({ length: totalPages }, (_, i) => i + 1)
+      .filter((page) => {
+        return (
+          page === 1 ||
+          page === totalPages ||
+          (page >= currentPage - 2 && page <= currentPage + 2)
+        );
+      })
+      .reduce((acc, page, i, arr) => {
+        if (i > 0 && page - arr[i - 1] > 1) acc.push("...");
+        acc.push(page);
+        return acc;
+      }, []);
+  }, [currentPage, totalPages]);
+
   return (
     <div className="space-y-6">
       {(showRoleDropdown || filters.length > 0 || sortOptions.length > 0) && (
@@ -191,37 +207,24 @@ export default function FilmGrid({
                 {"<"}
               </Button>
 
-              {Array.from({ length: totalPages }, (_, i) => i + 1)
-                .filter((page) => {
-                  return (
-                    page === 1 ||
-                    page === totalPages ||
-                    (page >= currentPage - 2 && page <= currentPage + 2)
-                  );
-                })
-                .reduce((acc, page, i, arr) => {
-                  if (i > 0 && page - arr[i - 1] > 1) acc.push("...");
-                  acc.push(page);
-                  return acc;
-                }, [])
-                .map((page, i) =>
-                  page === "..." ? (
-                    <span
-                      key={`ellipsis-${i}`}
-                      className="px-3 py-1 text-gray-400 select-none"
-                    >
-                      ...
-                    </span>
-                  ) : (
-                    <Button
-                      key={page}
-                      variant={page === currentPage ? "primary" : "secondary"}
-                      onClick={() => setCurrentPage(page)}
-                    >
-                      {page}
-                    </Button>
-                  )
-                )}
+              {paginationPages.map((page, i) =>
+                page === "..." ? (
+                  <span
+                    key={`ellipsis-${i}`}
+                    className="px-3 py-1 text-gray-400 select-none"
+                  >
+                    ...
+                  </span>
+                ) : (
+                  <Button
+                    key={page}
+                    variant={page === currentPage ? "primary" : "secondary"}
+                    onClick={() => setCurrentPage(page)}
+                  >
+                    {page}
+                  </Button>
+                )
+              )}
 
               <Button
                 variant="secondary"

--- a/frontend/src/features/films/FilmHeader.jsx
+++ b/frontend/src/features/films/FilmHeader.jsx
@@ -1,9 +1,14 @@
-export default function FilmHeader({ film }) {
-  const directors = film.crew?.filter(
-    (member) => member.role.name.toLowerCase() === "director"
-  ) || [];
+import { useMemo } from "react";
 
-  const directorNames = directors.map(d => d.person.name);
+export default function FilmHeader({ film }) {
+  const directorNames = useMemo(() => {
+    const directors =
+      film.crew?.filter(
+        (member) => member.role.name.toLowerCase() === "director"
+      ) || [];
+
+    return directors.map((d) => d.person.name);
+  }, [film.crew]);
   const hasDirectors = directorNames.length > 0;
 
   return (


### PR DESCRIPTION
## Summary
- memoize film header director names to avoid unnecessary recalculations
- memoize film grid pagination pages for stable rendering

## Testing
- `npm run lint` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@eslint/js' imported from eslint.config.js; lint errors found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b2618908832d8517067898d0b5ea